### PR TITLE
Added .vscode with initial recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "eamodio.gitlens",
+        "vscode-icons-team.vscode-icons"
+    ]
+}


### PR DESCRIPTION
Need to create a `package.json`. Want to use the latest `npm` CLI. For this need to use `nvm` (install it if not yet done) to install and use latest LTS node version.

Current versions:

- `node -v` -> v18.15.0
- `npm -v` -> 9.5.0
- `yarn -v` -> 1.22.19
	- Switching to `pnpm`
	
Switch to currently latest LTS NodeJS version 20.18.0:

- `nvm install 20.18.0`
- `nvm use 20.18.0`
	
Install `pnpm` https://pnpm.io/installation

- `npm install -g pnpm`
-  After installing `pnpm` - notice suggested updating `npm` - let's do that for completion sake.
     - `npm install -g npm@10.9.0`
	
Switched versions:

- `node -v` -> v20.18.0
- `npm -v` -> 10.9.0
- `pnpm -v` -> 9.12.2

Using `VSCode` - already have some extensions enabled. Will disable all for Workspace and install/enable others as the time goes. Want to emulate a clean start. Enabling the following as I'm just too used to them.

- GitLens https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens
- VSCode Icons https://marketplace.visualstudio.com/items?itemName=vscode-icons-team.vscode-icons
- Need to keep track of extensions. Will be adding all used extensions to the Workspace recommendations.