### PR TITLE
Initial typescript setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-console.log("Hello World!")

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "tilts",
   "version": "0.0.1",
   "description": "Work-in-progress repository to create an evergreen typescript starter.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "start": "node index.js"
+    "build": "tsc",
+    "start": "node dist/index.js"
   },
   "repository": {
     "type": "git",
@@ -23,5 +24,9 @@
   "bugs": {
     "url": "https://github.com/sertru/TILTS/issues"
   },
-  "homepage": "https://github.com/sertru/TILTS#readme"
+  "homepage": "https://github.com/sertru/TILTS#readme",
+  "devDependencies": {
+    "@types/node": "22.8.1",
+    "typescript": "5.6.3"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,39 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: 22.8.1
+        version: 22.8.1
+      typescript:
+        specifier: 5.6.3
+        version: 5.6.3
+
+packages:
+
+  '@types/node@22.8.1':
+    resolution: {integrity: sha512-k6Gi8Yyo8EtrNtkHXutUu2corfDf9su95VYVP10aGYMMROM6SAItZi0w1XszA6RtWTHSVp5OeFof37w0IEqCQg==}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+snapshots:
+
+  '@types/node@22.8.1':
+    dependencies:
+      undici-types: 6.19.8
+
+  typescript@5.6.3: {}
+
+  undici-types@6.19.8: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,6 @@
+
+const main = ():void => {
+    console.log("Hello World!")
+}
+
+main()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "lib": ["ES2023"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "target": "ES2023",
+    "outDir": "dist",
+
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  }
+}


### PR DESCRIPTION
Adding `"git.autofetch": true,` to global settings to get local updates whenever a PR is committed without fetching explicitly.

Time to install and set up the latest typescript version as a dev dependency:
- use `pnpm -h` and `pnpm add -h` to check for available commands 
- `pnpm add typescript -D` -> `typescript 5.6.3` (remove ^ from package.json)
	- `pnpm i` to align the `^` removal.
- `pnpm tsc -v` -> `5.6.3` - making sure that typescript CLI is available for use.
- time to add `.gitignore` and add `node_modules` to it
- `pnpm tsc -h` -> `pnpm tsc --init`
	- Too much comments, removing all
	- Using `https://github.com/tsconfig/bases?tab=readme-ov-file#centralized-recommendations-for-tsconfig-bases` and `Node 20` as a base, as Node 20 is current LTS.
	- Aligning lib and target to be `ES2023`
- add node types to make vscode recognize node-specific stuff in typescript files
	- `pnpm add @types/node -D`
- transform `index.js` to `index.ts`, move it to an `src` folder, adjust a little, add `"outDir": "dist",` to `tsconfig.json`, add `build` script to package.json, add `dist` to `.gitignore`
- adjust paths to `index.js` after running `pnpm build` in `package.json`