### PR TITLE
bun updated to 1.1.42

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ An evergreen typescript starter using:
 | | Dependency | Version|
 | :--: | :--: | :--: |
 | <img height="50" src="https://user-images.githubusercontent.com/25181517/183568594-85e280a7-0d7e-4d1a-9028-c8c2209e073c.png" alt="Node.js" title="Node.js"> | [Node.js](https://nodejs.org/en) | v22.12.0 (LTS) |
-| <img height="50" src="https://user-images.githubusercontent.com/25181517/121401671-49102800-c959-11eb-9f6f-74d49a5e1774.png" alt="npm" title="npm"/> | [npm](https://www.npmjs.com/package/npm) |  v10.9.2 |
+| <img height="50" src="https://user-images.githubusercontent.com/25181517/121401671-49102800-c959-11eb-9f6f-74d49a5e1774.png" alt="npm" title="npm"/> | [npm](https://www.npmjs.com/package/npm) |  v11.0.0 |
 | <img height="50" src="https://user-images.githubusercontent.com/25181517/183890598-19a0ac2d-e88a-4005-a8df-1ee36782fde1.png" alt="Typescript" title="Typescript"/> | [Typescript](https://www.typescriptlang.org) | v5.7.2 |
-| <img height="50" src="https://github.com/marwin1991/profile-technology-icons/assets/136815194/7e9599e9-0570-4bb6-b17f-676ed589912f" alt="Bun.js" title="Bun.js"/> | [Bun](https://bun.sh) | v1.1.38 |
+| <img height="50" src="https://github.com/marwin1991/profile-technology-icons/assets/136815194/7e9599e9-0570-4bb6-b17f-676ed589912f" alt="Bun.js" title="Bun.js"/> | [Bun](https://bun.sh) | v1.1.42 |
 | <img height="50" src="https://embed.zenn.studio/api/optimize-og-image/fc473601866af274a8c1/https%3A%2F%2Fbiomejs.gallerycdn.vsassets.io%2Fextensions%2Fbiomejs%2Fbiome%2F2024.10.131712%2F1728839567274%2FMicrosoft.VisualStudio.Services.Icons.Default" alt="Biome" title="Biome"/> | [Biome](https://biomejs.dev) | v1.9.4 |
 
 ## Setup

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dist": "bun clean && bun dist:cjs && bun dist:esm",
     "start": "bun src/index.ts",
     "up": "bun outdated && bun update --stable && bun upgrade && npm i npm -g --latest",
-    "it-works": "bun dist && bun start && node dist/cjs/index.js && node dist/esm/index.js && bun test"
+    "it-works": "bun dist && bun start && node dist/cjs/index.js && node dist/esm/index.js && bun test",
+    "versions": "echo '\nNode.js:' && node -v && echo '\nnpm:' && npm -v && echo '\nTypescript:' && tsc -v && echo '\nBun:' && bun -v && echo '\nBiome:' && bun biome -V"
   },
   "devDependencies": {
     "@biomejs/biome": "1.9.4",


### PR DESCRIPTION
- `bun up`
- `bun upgrade`
   - for some reason, upgrade from `bun up` did not apply the first time, maybe because I ran the script from package.json on-hover popup
 - also added `versions` script to check which versions are currently used relatively quickly