### PR TITLE
tsconfig adjusted

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
 
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
 
-    "@types/node": ["@types/node@22.13.4", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-ywP2X0DYtX3y08eFVx5fNIw7/uIv8hYUKgXoK8oayJlLnKcRfEYCxWMVE1XagUdVtCJlZT1AU4LXEABW+L1Peg=="],
+    "@types/node": ["@types/node@22.13.5", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg=="],
 
     "@types/ws": ["@types/ws@8.5.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ=="],
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "clean": "rimraf ./dist",
     "dist:cjs": "tsc -p tsconfig.cjs.json && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
-    "dist:esm": "tsc -p tsconfig.esm.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
+    "dist:esm": "tsc -p tsconfig.json && echo '{\"type\": \"module\"}' > dist/esm/package.json",
     "dist": "bun clean && bun dist:cjs && bun dist:esm",
     "start": "bun src/index.ts",
     "dev": "bun --watch src/index.ts",
@@ -15,7 +15,7 @@
   "devDependencies": {
     "@biomejs/biome": "1.9.4",
     "@types/bun": "1.2.2",
-    "@types/node": "22.13.4",
+    "@types/node": "22.13.5",
     "rimraf": "6.0.1",
     "typescript": "5.7.3"
   },

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "./tsconfig.base.json",
-  "compilerOptions": {
-    "module": "Node16",
-    "outDir": "dist/esm",
-    "target": "ES2024"
-  }
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,10 @@
 {
+  // This is used both by VSCode and to build the esm output
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": ["./tsconfig.base.json", "./tsconfig.esm.json"]
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "outDir": "dist/esm",
+    "target": "ES2024"
+  }
 }


### PR DESCRIPTION
- weekly dependencies update
- tsconfig.json and tsconfig.esm.json were basically the same, so tsconfig.json is now used both by VSCode and esm dist building, and tsconfig.esm.json dropped. Dropping the base config did not make sense, as I'd rather avoid duplicating common params.