### PR TITLE
Deps update 02042025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
     "source.organizeImports": "explicit"
   },
   "typescript.tsdk": "node_modules\\typescript\\lib",
-  "npm.packageManager": "bun"
+  "npm.packageManager": "bun",
+  "terminal.integrated.env.windows": {
+    "PATH": "%USERPROFILE%\\.bun\\bin;${env:PATH}"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An evergreen typescript starter using:
 
 | | Dependency | Version|
 | :--: | :--: | :--: |
-| <img alt="Bun.js" title="Bun.js" height="50" src="https://github.com/marwin1991/profile-technology-icons/assets/136815194/7e9599e9-0570-4bb6-b17f-676ed589912f"/> | [Bun](https://bun.sh) | v1.2.7 |
+| <img alt="Bun.js" title="Bun.js" height="50" src="https://github.com/marwin1991/profile-technology-icons/assets/136815194/7e9599e9-0570-4bb6-b17f-676ed589912f"/> | [Bun](https://bun.sh) | v1.2.8 |
 | <img alt="Typescript" title="Typescript" height="50" src="https://user-images.githubusercontent.com/25181517/183890598-19a0ac2d-e88a-4005-a8df-1ee36782fde1.png"/> | [Typescript](https://www.typescriptlang.org) | v5.8.2 |
 | <img alt="Biome" title="Biome" height="50" src="https://embed.zenn.studio/api/optimize-og-image/fc473601866af274a8c1/https%3A%2F%2Fbiomejs.gallerycdn.vsassets.io%2Fextensions%2Fbiomejs%2Fbiome%2F2024.10.131712%2F1728839567274%2FMicrosoft.VisualStudio.Services.Icons.Default"/> | [Biome](https://biomejs.dev) | v1.9.4 |
 


### PR DESCRIPTION
update readme, as ependencies were already updated for bun 1.2.8.
Also, there seems to be some strange behavior between launching bun -v via package.json script vs from powershell terminal, as if there are 2 bun installations with different versions. Added a potential workaround to the settings that should force the PATH to to include the same path to bun exe folder, but need to re-check this again when bun is updated again.